### PR TITLE
added 'table-of-contents'-like readme for the docker katas page 

### DIFF
--- a/workshops/docker-deep-dive/katas/README.md
+++ b/workshops/docker-deep-dive/katas/README.md
@@ -1,0 +1,10 @@
+## Summary
+A quick overview of what these katas contain, in case you're here looking for something specific:
+- 1: intro, learn how to run a simple script in a Docker container, Docker workflow, running commands in Docker container
+- 2: expose ports of your container, run a simple API server from within it
+- 3: basic networking between containers (one makes a request to the other), learn about container IP addresses
+- 4: intro to Docker volumes: a (i.e. *one of multiple*) way to have data from your machine accessible in your docker container
+- 5: more advanced networking, creating a network yourself, workflow and commands for doing this and managing the different containers on this network
+- 6: more info about Docker networking commands, more in-depth setup/config of the network
+- 7: intro to `docker-compose`. As a beginner the main use of this is to replace very large Docker commands (with many config arguments being passed in) by a `.yaml` file for convenience and efficiency.
+- 8: says it's supposed to teach you about debugging Docker scripts. Mostly teaches you about powershell ¯\\_(ツ)_/¯


### PR DESCRIPTION
for faster reference and to save users some clicking and reading if they're looking for something specific (as I was today)